### PR TITLE
*sh: Use `>!` instead of `>` to create Base16 config

### DIFF
--- a/roles/dotfiles/files/.shells/colors
+++ b/roles/dotfiles/files/.shells/colors
@@ -22,7 +22,7 @@ color() {
   dark|light)
     FILE="$BASE16_DIR/base16-$SCHEME.$BACKGROUND.sh"
     if [[ -x "$FILE" ]]; then
-      echo "$SCHEME" > "$BASE16_CONFIG"
+      echo "$SCHEME" >! "$BASE16_CONFIG"
       echo "$BACKGROUND" >> "$BASE16_CONFIG"
       "$FILE"
     else


### PR DESCRIPTION
If the file already exists, `>` will throw an error instead of
overwriting the file by default. This can be changed by setting the
`clobber` option as has been done elsewhere in this project[0]. Although
this can be fine for day-to-day use, relying on this option in a script
introduces a hidden dependency that is easy enough to avoid by making
the desire to clobber explicit via `>!`. Changing this out will make
this script more robust and portable.

[0]: https://github.com/wincent/wincent/blob/94a0ae02/roles/dotfiles/files/.zshrc#L62