### PR TITLE
Zsh: add `color -` to switch back to previous color

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /roles/dotfiles/files/.mutt/scripts/vendor
 /roles/dotfiles/files/.npmrc
 /roles/dotfiles/files/.vim/.base16
+/roles/dotfiles/files/.vim/.base16.previous
 /roles/dotfiles/files/.vim/after/plugin/command-t.private.vim
 /roles/dotfiles/files/.vim/plugin/private.vim
 /roles/dotfiles/files/.vim/spell/en.utf-8.add.spl

--- a/roles/dotfiles/files/.zsh/colors
+++ b/roles/dotfiles/files/.zsh/colors
@@ -41,6 +41,7 @@ luma() {
 color() {
   local SCHEME="$1"
   local BASE16_DIR=~/.zsh/base16-shell/scripts
+  local BASE16_CONFIG_PREVIOUS="$BASE16_CONFIG.previous"
 
   if [ $# -eq 0 ]; then
     if [ -s "$BASE16_CONFIG" ]; then
@@ -64,7 +65,21 @@ color() {
       sed -E 's/\.sh//' | \
       column
       ;;
+  -)
+    local PREVIOUS_SCHEME=$(head -n1 "$BASE16_CONFIG_PREVIOUS")
+    color "$PREVIOUS_SCHEME"
+    ;;
   *)
+    # Check to see if the requested scheme is the same as the current scheme,
+    # and if it is, bail out. This avoids overwriting the previous scheme file
+    # with a duplicate, allowing `color -` to be more useful in more situations.
+    if [[ -s "$BASE16_CONFIG" ]]; then
+      local CURRENT_SCHEME=$(head -n1 "$BASE16_CONFIG")
+      if [[ "$SCHEME" = "$CURRENT_SCHEME" ]]; then
+        return
+      fi
+    fi
+
     FILE="$BASE16_DIR/base16-$SCHEME.sh"
     if [[ -e "$FILE" ]]; then
       local BG=$(grep color_background= "$FILE" | cut -d \" -f2 | sed -e 's#/##g')
@@ -73,6 +88,10 @@ color() {
       local BACKGROUND=dark
       if [ "$LIGHT" -eq 1 ]; then
         BACKGROUND=light
+      fi
+
+      if [[ -s "$BASE16_CONFIG" ]]; then
+        mv -f "$BASE16_CONFIG" "$BASE16_CONFIG_PREVIOUS"
       fi
 
       echo "$SCHEME" >! "$BASE16_CONFIG"


### PR DESCRIPTION
If I am checking out a bunch of color schemes, I often find myself
switching to a theme for a bit and then wanting to switch back to the
one I was previously using. This commit adds this feature to the color
script by teaching it to respond to the special "-" argument. This works
similarly to how other commands like `cd -` and `git checkout -` work,
so it feels pretty natural.

I considered writing the previous color as metadata to my existing
base16 config file to avoid adding another file, but I decided that this
approach would be a little easier to implement so I am rolling with it
for now. But in the future, that might be a possible avenue for
improvement.

I originally did this in
https://github.com/lencioni/dotfiles/commit/249de701 and thought you
might be interested.