### PR TITLE
Wrong prefix used in comment in `.tmux.conf` comment

### DIFF
--- a/roles/dotfiles/files/.tmux.conf
+++ b/roles/dotfiles/files/.tmux.conf
@@ -97,7 +97,7 @@ set -g history-limit 4096
 set -g base-index 1
 set -g pane-base-index 1
 
-# Don't wait for an escape sequence after seeing C-a.
+# Don't wait for an escape sequence after seeing C-Space.
 set -s escape-time 0
 
 # Dynamically update iTerm tab and window titles.


### PR DESCRIPTION
No issue here, was reading the `.tmux.conf` for some inspiration for a redo of my own.

Small outdated comment in implying prefix was `C-a`.

Debated whether to actually write the word `prefix` or not, but went with `C-Space` instead.