### PR TITLE
Zsh Functions: allow tmux session creation in directory with '.' in name

### DIFF
--- a/roles/dotfiles/files/.zsh/functions
+++ b/roles/dotfiles/files/.zsh/functions
@@ -103,7 +103,7 @@ function tmux() {
   fi
 
   # Attach to existing session, or create one, based on current directory.
-  SESSION_NAME=$(basename "$(pwd)")
+  SESSION_NAME=$(basename "${$(pwd)//[.]/_}")
   env SSH_AUTH_SOCK=$SOCK_SYMLINK tmux new -A -s "$SESSION_NAME"
 }
 


### PR DESCRIPTION
## Proposed Changes
 - Allow tmux to create a new session named after the current directory containing a '.' by replacing '.' with '_'. 
