### PR TITLE
tmux: Escape backslash for tmux 3

### DIFF
--- a/roles/dotfiles/files/.tmux.conf
+++ b/roles/dotfiles/files/.tmux.conf
@@ -47,7 +47,7 @@ bind-key p select-layout -o
 
 # Intuitive window-splitting keys.
 bind-key | split-window -h -c '#{pane_current_path}' # normally prefix-%
-bind-key \ split-window -h -c '#{pane_current_path}' # normally prefix-%
+bind-key \\ split-window -h -c '#{pane_current_path}' # normally prefix-%
 bind-key - split-window -v -c '#{pane_current_path}' # normally prefix-"
 
 bind-key < swap-window -t -1 # Move window left.


### PR DESCRIPTION
One of the breaking changes in v3:

> INCOMPATIBLE: tmux's configuration parsing has changed to use yacc(1).
> There is one incompatible change: a \ on its own must be escaped or
> quoted as either \\ or '\' (the latter works on older tmux versions).

I originally made this change in my dotfiles here:

  https://github.com/lencioni/dotfiles/commit/369fdf588309366f37d58411226ebbded8b2fe41

It looks like this could also be quoted so it continues to work on
older versions