### PR TITLE
add spec as a test file indicator

### DIFF
--- a/aspects/vim/files/.vim/ftdetect/jest.vim
+++ b/aspects/vim/files/.vim/ftdetect/jest.vim
@@ -11,7 +11,7 @@ function! s:Test()
 
   let l:file=expand('<afile>')
 
-  if match(l:file, '\v(_spec|Spec|-test|\.test)\.(js|jsx|ts|tsx)$') != -1 ||
+  if match(l:file, '\v(_spec|spec|Spec|-test|\.test)\.(js|jsx|ts|tsx)$') != -1 ||
         \ match(l:file, '\v/__tests__|tests?/.+\.(js|jsx|ts|tsx)$') != -1
     noautocmd set filetype+=.jest
   endif


### PR DESCRIPTION
## Proposed Changes

-   detect jest test files that have `spec` in the name, ie `index.spec.js`