### PR TITLE
Add `color rand` for zsh

### DIFF
--- a/aspects/dotfiles/files/.zsh/colors
+++ b/aspects/dotfiles/files/.zsh/colors
@@ -96,6 +96,7 @@ color() {
 
   if [ "$2" = "-q" -o "$2" = "--quiet" ]; then
     local quiet=1
+    shift
   fi
   local ALL_SCHEMES=($(find "$BASE16_DIR" -name 'base16-*.sh' | \
         sed -E 's|.+/base16-||' | \

--- a/aspects/dotfiles/files/.zsh/colors
+++ b/aspects/dotfiles/files/.zsh/colors
@@ -94,22 +94,46 @@ color() {
     fi
   fi
 
+  while [ "$#" -gt 0 ]; do
+    case "$2" in
+      "-q"|"--quiet")
+        local quiet=1
+        shift
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+  local ALL_SCHEMES=($(find "$BASE16_DIR" -name 'base16-*.sh' | \
+        sed -E 's|.+/base16-||' | \
+        sed -E 's/\.sh//' | \
+        grep "${2:-.}" | \
+        sort
+        ))
+
   case "$SCHEME" in
   help)
     echo 'color                                   (show current scheme)'
     echo 'color default-dark|grayscale-light|...  (switch to scheme)'
     echo 'color help                              (show this help)'
     echo 'color ls [pattern]                      (list available schemes)'
+    echo
+    echo 'Chose Random Scheme:'
+    echo 'color rand [-q/--quiet] [pattern]       (chose a random scheme)'
     return
     ;;
   ls)
-    find "$BASE16_DIR" -name 'base16-*.sh' | \
-      sed -E 's|.+/base16-||' | \
-      sed -E 's/\.sh//' | \
-      grep "${2:-.}" | \
-      sort | \
+    printf '%s\n' "${ALL_SCHEMES[@]}" | \
       column
       ;;
+  rand)
+    local random_color=${ALL_SCHEMES[$(( $RANDOM % ${#ALL_SCHEMES[@]} + 1 ))]}
+    if [[ -z "$quiet" ]]; then
+      echo "$random_color"
+    fi
+    __color "$random_color"
+    ;;
   -)
     if [[ -s "$BASE16_CONFIG_PREVIOUS" ]]; then
       local PREVIOUS_SCHEME=$(head -1 "$BASE16_CONFIG_PREVIOUS")

--- a/aspects/dotfiles/files/.zsh/colors
+++ b/aspects/dotfiles/files/.zsh/colors
@@ -94,17 +94,9 @@ color() {
     fi
   fi
 
-  while [ "$#" -gt 0 ]; do
-    case "$2" in
-      "-q"|"--quiet")
-        local quiet=1
-        shift
-        ;;
-      *)
-        break
-        ;;
-    esac
-  done
+  if [ "$2" = "-q" -o "$2" = "--quiet" ]; then
+    local quiet=1
+  fi
   local ALL_SCHEMES=($(find "$BASE16_DIR" -name 'base16-*.sh' | \
         sed -E 's|.+/base16-||' | \
         sed -E 's/\.sh//' | \


### PR DESCRIPTION
For selecting a random color scheme run `color rand` or add another
pattern, like `color rand dark`. By default it will print the name of
the new color scheme, but you can surpress this by passing in `-q` or
`--quiet` before the (optional) pattern.

Fixes #94