### PR TITLE
fix(vim): Update lsp highlights and `vim.lsp.callbacks`

### DIFF
--- a/aspects/vim/files/.vim/after/plugin/nvim-lspconfig.vim
+++ b/aspects/vim/files/.vim/after/plugin/nvim-lspconfig.vim
@@ -4,10 +4,10 @@ endif
 
 lua require'wincent.lsp'.init()
 
-sign define LspDiagnosticsErrorSign text=✖
-sign define LspDiagnosticsWarningSign text=⚠
-sign define LspDiagnosticsInformationSign text=ℹ
-sign define LspDiagnosticsHintSign text=➤
+sign define LspDiagnosticsSignError text=✖
+sign define LspDiagnosticsSignWarning text=⚠
+sign define LspDiagnosticsSignInformation text=ℹ
+sign define LspDiagnosticsSignHint text=➤
 
 augroup WincentLanguageClientAutocmds
   autocmd!

--- a/aspects/vim/files/.vim/lua/wincent/lsp.lua
+++ b/aspects/vim/files/.vim/lua/wincent/lsp.lua
@@ -113,8 +113,8 @@ lsp.init = function ()
 
   -- Override hover winhighlight.
   local method = 'textDocument/hover'
-  local hover = vim.lsp.callbacks[method]
-  vim.lsp.callbacks[method] = function (_, method, result)
+  local hover = vim.lsp.handlers[method]
+  vim.lsp.handlers[method] = function (_, method, result)
      hover(_, method, result)
 
      for _, winnr in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
@@ -133,16 +133,16 @@ end
 lsp.set_up_highlights = function ()
   local pinnacle = require'wincent.pinnacle'
 
-  vim.cmd('highlight LspDiagnosticsError ' .. pinnacle.decorate('italic,underline', 'ModeMsg'))
+  vim.cmd('highlight LspDiagnosticsDefaultError ' .. pinnacle.decorate('italic,underline', 'ModeMsg'))
 
-  vim.cmd('highlight LspDiagnosticsHint ' .. pinnacle.decorate('bold,italic,underline', 'Type'))
+  vim.cmd('highlight LspDiagnosticsDefaultHint ' .. pinnacle.decorate('bold,italic,underline', 'Type'))
 
-  vim.cmd('highlight LspDiagnosticsHintSign ' .. pinnacle.highlight({
+  vim.cmd('highlight LspDiagnosticsSignHint ' .. pinnacle.highlight({
     bg = pinnacle.extract_bg('ColorColumn'),
     fg = pinnacle.extract_fg('Type'),
   }))
 
-  vim.cmd('highlight LspDiagnosticsErrorSign ' .. pinnacle.highlight({
+  vim.cmd('highlight LspDiagnosticsSignError ' .. pinnacle.highlight({
     bg = pinnacle.extract_bg('ColorColumn'),
     fg = pinnacle.extract_fg('ErrorMsg'),
   }))


### PR DESCRIPTION
neovim/neovim#12655 made breaking changes renaming highlight groups for
LspDiagnostic. It also moved `vim.lsp.callbacks` to `vim.lsp.handlers`

Since we're installing the nightly build, we should update this so that
a fresh init can work off the bat.
